### PR TITLE
Fix Google Calendar share URL

### DIFF
--- a/components/calendar.tsx
+++ b/components/calendar.tsx
@@ -48,7 +48,7 @@ const Calendar: FC = () => {
       <a
         className="ml-auto font-bold text-teal underline transition hover:text-coral"
         href={
-          process.env.NEXT_PUBLIC_NEXT_PUBLIC_GOOGLE_CALENDAR_SHARE_URL || ''
+          process.env.NEXT_PUBLIC_GOOGLE_CALENDAR_SHARE_URL || ''
         }
         target="_blank"
         rel="noreferrer"


### PR DESCRIPTION
Fix typo in Google calendar share url link environment variable. Link works now in develop.turunwappuradio.com