### PR TITLE
Fix HTML metadata

### DIFF
--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -48,12 +48,11 @@ const ContentPage: NextPage<ContentPageProps> = ({
       <Head>
         <title>{title}</title>
         <meta name="og:title" content={title} />
-        <meta name="og:site_name" content={title} />
         <meta name="twitter:title" content={title} />
 
-        <meta name="description" content={description} />
-        <meta name="og:description" content={description} />
-        <meta name="twitter:description" content={description} />
+        {heroSubtext && <meta name="description" content={heroSubtext} />}
+        {heroSubtext && <meta name="og:description" content={heroSubtext} />}
+        {heroSubtext && <meta name="twitter:description" content={heroSubtext} />}
       </Head>
       <Hero
         image={heroImage}

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -40,15 +40,11 @@ class MyDocument extends Document {
 
           <meta name="theme-color" content="#001326" />
 
-          <meta property="og:title" content="Turun Wappuradio" />
           <meta property="og:site_name" content="Turun Wappuradio" />
-          <meta property="og:description" content="Lähetys 20.–30.4." />
           <meta property="og:image" content="/logo@192.png" />
           <meta property="og:url" content="https://www.turunwappuradio.com" />
 
           {/* Social media stuff */}
-          <meta name="twitter:title" content="Turun Wappuradio" />
-          <meta name="twitter:description" content="Lähetys 20.–30.4." />
           <meta name="twitter:image" content="/logo@192.png" />
           <meta name="twitter:card" content="summary_large_image" />
 

--- a/pages/arkisto/[showlistId].tsx
+++ b/pages/arkisto/[showlistId].tsx
@@ -48,7 +48,6 @@ export const ShowListPage: NextPage<ShowListPageProps> = ({
       <Head>
         <title>{title}</title>
         <meta name="og:title" content={title} />
-        <meta name="og:site_name" content={title} />
         <meta name="twitter:title" content={title} />
 
         <meta name="description" content={heroSubtext} />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -81,7 +81,6 @@ const Index: NextPage<IndexProps & PlayerControls> = ({
       <Head>
         <title>{heroTitle}</title>
         <meta name="og:title" content={heroTitle} />
-        <meta name="og:site_name" content={heroTitle} />
         <meta name="twitter:title" content={heroTitle} />
 
         <meta name="description" content={heroSubtext} />


### PR DESCRIPTION
* Poistetaan kovakoodatut metadatakentät `title` ja `description`.
* Poistetaan sivukohtaiset `site_name`-kentät.
* Käytetään alasivuilla `heroSubtext`-proppia kuvaustekstinä.