### PR TITLE
Chore: (ehdotus) Järjestetään importit automaattisesti

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,11 +1,6 @@
 {
-  "extends": [
-    "next",
-    "prettier"
-  ],
-  "plugins": [
-    "simple-import-sort"
-  ],
+  "extends": ["next", "prettier"],
+  "plugins": ["simple-import-sort"],
   "rules": {
     "semi": 2,
     "simple-import-sort/imports": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,30 @@
 {
-  "extends": ["next", "prettier"],
+  "extends": [
+    "next",
+    "prettier"
+  ],
+  "plugins": [
+    "simple-import-sort"
+  ],
   "rules": {
-    "semi": 2
+    "semi": 2,
+    "simple-import-sort/imports": [
+      2,
+      {
+        "groups": [
+          [
+            "^\\u0000", // Side effect imports.
+            "^react.*",
+            "^next.*",
+            "^node:",
+            "^@?\\w" // Things that start with a letter (or digit or underscore), or `@` followed by a letter.
+          ],
+          [
+            "^", // Absolute imports and other imports such as `@/foo`. Anything not matched in another group.
+            "^\\." // Anything that starts with a dot.
+          ]
+        ]
+      }
+    ]
   }
 }

--- a/archiver/archive.ts
+++ b/archiver/archive.ts
@@ -1,4 +1,8 @@
-import { Show, Showlist, showsToGroups } from 'scripts/google/showlistHelpers';
+import {
+  Show,
+  Showlist,
+  showsToGroups,
+} from '@/scripts/google/showlistHelpers';
 
 const showlistBaseUrl = process.env.ARCHIVE_SOURCE_URL;
 const emptyResponse = { showsByDate: [], weekKeys: {} } as const;

--- a/archiver/archiveCrawlers.ts
+++ b/archiver/archiveCrawlers.ts
@@ -1,9 +1,9 @@
-import { parseSheetToShowList } from 'scripts/google/client';
-import { GoogleConfigSheets, getSheet } from 'scripts/google/google';
 import { mkdirSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { getImagePath } from 'utils/fileHelpers';
+
+import { parseSheetToShowList } from '@/scripts/google/client';
+import { getSheet, GoogleConfigSheets } from '@/scripts/google/google';
 
 export const archiveOldShowlists = async () => {
   // NOTE: Uncomment for archiving google sheet data

--- a/components/ShoutBox/messageformatter.tsx
+++ b/components/ShoutBox/messageformatter.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import NameFormatter from './nameformatter';
 
 interface MessageFormatterProps {

--- a/components/ShoutBox/messageinput.tsx
+++ b/components/ShoutBox/messageinput.tsx
@@ -1,5 +1,6 @@
 import React, { ChangeEvent, Component, useEffect, useState } from 'react';
 import { AiOutlineSend } from 'react-icons/ai';
+
 import NameFormatter from './nameformatter';
 import TextField from './textfield';
 

--- a/components/ShoutBox/nameformatter.tsx
+++ b/components/ShoutBox/nameformatter.tsx
@@ -1,6 +1,6 @@
-import { format } from 'date-fns';
 import React from 'react';
 import Image from 'next/image';
+import { format } from 'date-fns';
 
 interface NameFormatterProps {
   name: string;

--- a/components/ShoutBox/nameinput.tsx
+++ b/components/ShoutBox/nameinput.tsx
@@ -1,4 +1,5 @@
 import React, { ChangeEvent, useState } from 'react';
+
 import TextField from './textfield';
 
 const isButtonDisabled = (name: string) => name === '';

--- a/components/ShoutBox/shoutbox.tsx
+++ b/components/ShoutBox/shoutbox.tsx
@@ -1,10 +1,10 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { GrFormClose } from 'react-icons/gr';
 
+import useShoutBoxAndVideo from '../../hooks/useShoutboxAndVideo';
+import MessageFormatter from './messageformatter';
 import MessageInput from './messageinput';
 import NameInput from './nameinput';
-import MessageFormatter from './messageformatter';
-import useShoutBoxAndVideo from '../../hooks/useShoutboxAndVideo';
 
 const wsURL = process.env.NEXT_PUBLIC_SHOUTBOX_SOURCE || 'ws://localhost:3030';
 

--- a/components/button.tsx
+++ b/components/button.tsx
@@ -1,5 +1,5 @@
-import Link from 'next/link';
 import { FC, ReactNode } from 'react';
+import Link from 'next/link';
 
 const buttonStyle =
   'bg-teal px-6 md:px-8 py-2 md:py-3 text-blue font-bold hover:bg-coral transition ease-in-out rounded';

--- a/components/calendar.tsx
+++ b/components/calendar.tsx
@@ -1,5 +1,5 @@
-import { FC, useState, useEffect } from 'react';
-import { startOfDay, format, parseISO, isSameDay } from 'date-fns';
+import { FC, useEffect, useState } from 'react';
+import { format, isSameDay, parseISO, startOfDay } from 'date-fns';
 import fi from 'date-fns/locale/fi';
 
 // Fetch next events but not more than 6 months from now

--- a/components/controls.tsx
+++ b/components/controls.tsx
@@ -1,4 +1,4 @@
-import { FiPlay, FiPause, FiVolumeX, FiVolume2 } from 'react-icons/fi';
+import { FiPause, FiPlay, FiVolume2, FiVolumeX } from 'react-icons/fi';
 
 import VolumeSlider from './volumeSlider';
 

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,14 +1,14 @@
-import Image from 'next/image';
-import Link from 'next/link';
 import {
-  AiOutlineInstagram,
   AiFillFacebook,
-  AiOutlineMail,
   AiFillGithub,
+  AiOutlineInstagram,
+  AiOutlineMail,
 } from 'react-icons/ai';
 import { FaDiscord, FaTelegramPlane } from 'react-icons/fa';
+import Image from 'next/image';
+import Link from 'next/link';
 
-import { NavigationItem } from 'contentful/client';
+import { NavigationItem } from '@/contentful/client';
 
 interface FooterProps {
   navigationItems: NavigationItem[];

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -1,11 +1,11 @@
+import { FC, useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
-import { FC, useState } from 'react';
 
-import { contentfulImageLoader } from 'contentful/contentfulImageLoader';
-import { LinkButton } from './button';
-import { NavigationItem } from 'contentful/client';
+import { NavigationItem } from '@/contentful/client';
+import { contentfulImageLoader } from '@/contentful/contentfulImageLoader';
 import heroImage from '../public/hero.webp';
+import { LinkButton } from './button';
 import Hamburger from './hamburger/hamburger';
 import Menu from './menu';
 

--- a/components/menu.tsx
+++ b/components/menu.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 
-import { NavigationItem } from 'contentful/client';
+import { NavigationItem } from '@/contentful/client';
 
 interface MenuProps {
   navigationItems: NavigationItem[];

--- a/components/player.tsx
+++ b/components/player.tsx
@@ -1,12 +1,12 @@
-import Image from 'next/image';
 import { useEffect, useState } from 'react';
+import { FiMessageSquare, FiPause, FiPlay, FiVideo } from 'react-icons/fi';
+import Image from 'next/image';
 import { format } from 'date-fns';
 
-import testcard from '../public/testcard.webp';
+import useShoutBoxAndVideo from '@/hooks/useShoutboxAndVideo';
+import { Show } from '@/scripts/google/showlistHelpers';
 import placeholderImage from '../public/kuva_puuttuu_v2.jpeg';
-import useShoutBoxAndVideo from 'hooks/useShoutboxAndVideo';
-import { FiPause, FiPlay, FiMessageSquare, FiVideo } from 'react-icons/fi';
-import { Show } from 'scripts/google/showlistHelpers';
+import testcard from '../public/testcard.webp';
 
 const SHOW_REFRESH_TIME = 10000; // 10 seconds
 

--- a/components/playerControlPanel.tsx
+++ b/components/playerControlPanel.tsx
@@ -1,4 +1,4 @@
-import useMetadata from 'hooks/useMetadata';
+import useMetadata from '@/hooks/useMetadata';
 import Controls from './controls';
 
 interface PlayerControlPanelProps {

--- a/components/responsiveShowlist.tsx
+++ b/components/responsiveShowlist.tsx
@@ -1,10 +1,10 @@
-import { format, parse } from 'date-fns';
-import fi from 'date-fns/locale/fi';
 import { Dispatch, SetStateAction, useState } from 'react';
 import { BsArrowLeft, BsArrowRight } from 'react-icons/bs';
+import { format, parse } from 'date-fns';
+import fi from 'date-fns/locale/fi';
 
-import { ShowCard } from 'components/showcard';
-import { Show } from 'scripts/google/showlistHelpers';
+import { ShowCard } from '@/components/showcard';
+import { Show } from '@/scripts/google/showlistHelpers';
 
 interface NavButton {
   value: string | null;

--- a/components/richtext.tsx
+++ b/components/richtext.tsx
@@ -1,10 +1,10 @@
 import React, { FC } from 'react';
-import { MARKS, BLOCKS, INLINES } from '@contentful/rich-text-types';
+import Image from 'next/image';
 import {
   documentToReactComponents,
   Options,
 } from '@contentful/rich-text-react-renderer';
-import Image from 'next/image';
+import { BLOCKS, INLINES, MARKS } from '@contentful/rich-text-types';
 
 import { contentfulImageLoader } from '../contentful/contentfulImageLoader';
 import { LinkButton } from './button';

--- a/components/showcard.tsx
+++ b/components/showcard.tsx
@@ -1,10 +1,10 @@
+import { useState } from 'react';
+import Image from 'next/image';
 import { format } from 'date-fns';
 import fi from 'date-fns/locale/fi';
-import Image from 'next/image';
-import { useState } from 'react';
 
+import { Show } from '@/scripts/google/showlistHelpers';
 import placeholderImage from '../public/kuva_puuttuu_v2.jpeg';
-import { Show } from 'scripts/google/showlistHelpers';
 
 interface ShowCard {
   show: Show;

--- a/components/showlist.tsx
+++ b/components/showlist.tsx
@@ -1,10 +1,10 @@
 import { useState } from 'react';
 
-import { Show } from 'scripts/google/showlistHelpers';
+import { useViewport } from '@/hooks/useViewport';
+import { Show } from '@/scripts/google/showlistHelpers';
+import { ModeButton } from './button';
 import ResponsiveShowlist from './responsiveShowlist';
 import ShowlistMap from './showlistMap';
-import { ModeButton } from './button';
-import { useViewport } from 'hooks/useViewport';
 
 interface ShowlistProps {
   showsByDate: {

--- a/components/showlistMap.tsx
+++ b/components/showlistMap.tsx
@@ -3,7 +3,7 @@ import { differenceInMinutes, format, parse } from 'date-fns';
 import fi from 'date-fns/locale/fi';
 import { head, keys } from 'ramda';
 
-import { Show } from 'scripts/google/showlistHelpers';
+import { Show } from '@/scripts/google/showlistHelpers';
 import { ModeButton } from './button';
 import { ShowCard } from './showcard';
 import { WideScreencard } from './widescreen-card';

--- a/components/videoPlayer.tsx
+++ b/components/videoPlayer.tsx
@@ -1,5 +1,6 @@
-import useShoutBoxAndVideo from 'hooks/useShoutboxAndVideo';
 import { GrFormClose } from 'react-icons/gr';
+
+import useShoutBoxAndVideo from '@/hooks/useShoutboxAndVideo';
 
 const VideoPlayer = () => {
   const { videoOpen, setVideoOpen } = useShoutBoxAndVideo();

--- a/components/widescreen-card.tsx
+++ b/components/widescreen-card.tsx
@@ -1,4 +1,4 @@
-import { Color } from 'scripts/google/showlistHelpers';
+import { Color } from '@/scripts/google/showlistHelpers';
 
 interface WideScreenCardProps {
   text: string;

--- a/contentful/client.ts
+++ b/contentful/client.ts
@@ -4,6 +4,7 @@ import {
   InMemoryCache,
   NormalizedCacheObject,
 } from '@apollo/client';
+
 import {
   NavigationItemsDocument,
   NavigationItemsQuery,

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "eslint": "^8.9.0",
         "eslint-config-next": "^12.0.10",
         "eslint-config-prettier": "^8.3.0",
+        "eslint-plugin-simple-import-sort": "^12.0.0",
         "graphql-let": "^0.18.4",
         "postcss": "^8.4.6",
         "prettier": "^2.5.1",
@@ -6103,6 +6104,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-plugin-simple-import-sort": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.0.0.tgz",
+      "integrity": "sha512-8o0dVEdAkYap0Cn5kNeklaKcT1nUsa3LITWEuFk3nJifOoD+5JQGoyDUW2W/iPWwBsNBJpyJS9y4je/BgxLcyQ==",
+      "dev": true,
+      "peerDependencies": {
+        "eslint": ">=5.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -18152,6 +18162,13 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
       "integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
+      "dev": true,
+      "requires": {}
+    },
+    "eslint-plugin-simple-import-sort": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.0.0.tgz",
+      "integrity": "sha512-8o0dVEdAkYap0Cn5kNeklaKcT1nUsa3LITWEuFk3nJifOoD+5JQGoyDUW2W/iPWwBsNBJpyJS9y4je/BgxLcyQ==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eslint": "^8.9.0",
     "eslint-config-next": "^12.0.10",
     "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-simple-import-sort": "^12.0.0",
     "graphql-let": "^0.18.4",
     "postcss": "^8.4.6",
     "prettier": "^2.5.1",

--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -1,22 +1,22 @@
 import { GetStaticPaths, GetStaticProps, NextPage } from 'next';
 import Head from 'next/head';
 
+import Footer from '@/components/footer';
+import Hero from '@/components/hero';
+import RichText from '@/components/richtext';
 import {
   fetchContent,
   fetchNavigationItems,
   NavigationItem,
-} from 'contentful/client';
-import RichText from 'components/richtext';
-import {
-  ContentPagePathsDocument,
-  ContentPagePathsQuery,
-} from 'contentful/graphql/contentPagePaths.graphql';
+} from '@/contentful/client';
 import {
   ContentPageDocument,
   ContentPageQuery,
-} from 'contentful/graphql/contentPage.graphql';
-import Hero from 'components/hero';
-import Footer from 'components/footer';
+} from '@/contentful/graphql/contentPage.graphql';
+import {
+  ContentPagePathsDocument,
+  ContentPagePathsQuery,
+} from '@/contentful/graphql/contentPagePaths.graphql';
 
 interface ContentPageProps {
   name: string;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,11 +1,11 @@
+import 'tailwindcss/tailwind.css';
 import { createRef, useState } from 'react';
 import { AppProps } from 'next/app';
-import 'tailwindcss/tailwind.css';
 
-import PlayerControlPanel from 'components/playerControlPanel';
-import { ShoutBoxAndVideoProvider } from 'hooks/useShoutboxAndVideo';
-import { ChatWrapper } from 'components/ShoutBox/shoutbox';
-import VideoPlayer from 'components/videoPlayer';
+import PlayerControlPanel from '@/components/playerControlPanel';
+import { ChatWrapper } from '@/components/ShoutBox/shoutbox';
+import VideoPlayer from '@/components/videoPlayer';
+import { ShoutBoxAndVideoProvider } from '@/hooks/useShoutboxAndVideo';
 
 const AUDIO_STREAM_URL = 'https://player.turunwappuradio.com/wappuradio.mp3';
 

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,4 +1,4 @@
-import Document, { Html, Head, Main, NextScript } from 'next/document';
+import Document, { Head, Html, Main, NextScript } from 'next/document';
 
 // A custom Document for Next.js to inject Tailwind styles to the body.
 class MyDocument extends Document {

--- a/pages/api/archiver.ts
+++ b/pages/api/archiver.ts
@@ -1,5 +1,6 @@
-import { archiveOldShowlists } from 'archiver/archiveCrawlers';
 import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { archiveOldShowlists } from '@/archiver/archiveCrawlers';
 
 type ResponseData = {
   message: string;

--- a/pages/arkisto/[showlistId].tsx
+++ b/pages/arkisto/[showlistId].tsx
@@ -1,23 +1,23 @@
+import { BsArrowLeft } from 'react-icons/bs';
 import { GetStaticPaths, GetStaticProps, NextPage } from 'next';
 import Head from 'next/head';
+import Link from 'next/link';
 
-import { ShowlistPathsDocument } from 'contentful/graphql/showlistPaths.graphql';
+import { fetchArchivedShowlist } from '@/archiver/archive';
+import Hero from '@/components/hero';
+import { Showlist } from '@/components/showlist';
 import {
   fetchContent,
   fetchNavigationItems,
   NavigationItem,
-} from 'contentful/client';
-import { ShowlistPathsQuery } from 'contentful/graphql/showlistPaths.graphql';
+} from '@/contentful/client';
 import {
   ShowlistPageDocument,
   ShowlistPageQuery,
-} from 'contentful/graphql/showlistPage.graphql';
-import Hero from 'components/hero';
-import { Showlist } from 'components/showlist';
-import { BsArrowLeft } from 'react-icons/bs';
-import Link from 'next/link';
-import { fetchArchivedShowlist } from 'archiver/archive';
-import { Show } from 'scripts/google/showlistHelpers';
+} from '@/contentful/graphql/showlistPage.graphql';
+import { ShowlistPathsDocument } from '@/contentful/graphql/showlistPaths.graphql';
+import { ShowlistPathsQuery } from '@/contentful/graphql/showlistPaths.graphql';
+import { Show } from '@/scripts/google/showlistHelpers';
 
 interface ShowListPageProps {
   name: string;

--- a/pages/arkisto/index.tsx
+++ b/pages/arkisto/index.tsx
@@ -1,21 +1,21 @@
+import { BsArrowRight } from 'react-icons/bs';
 import { GetStaticProps, NextPage } from 'next';
 import Head from 'next/head';
-import { BsArrowRight } from 'react-icons/bs';
+import Image from 'next/image';
+import Link from 'next/link';
 
-import Hero from 'components/hero';
+import Footer from '@/components/footer';
+import Hero from '@/components/hero';
 import {
   fetchContent,
   fetchNavigationItems,
   NavigationItem,
-} from 'contentful/client';
+} from '@/contentful/client';
+import { contentfulImageLoader } from '@/contentful/contentfulImageLoader';
 import {
   ArchivePageDocument,
   ArchivePageQuery,
-} from 'contentful/graphql/archivePage.graphql';
-import Image from 'next/image';
-import { contentfulImageLoader } from 'contentful/contentfulImageLoader';
-import Footer from 'components/footer';
-import Link from 'next/link';
+} from '@/contentful/graphql/archivePage.graphql';
 
 interface ShowList {
   id?: string;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,22 +1,22 @@
-import Head from 'next/head';
 import { GetStaticProps, NextPage } from 'next';
+import Head from 'next/head';
+import Image from 'next/image';
 
+import Calendar from '@/components/calendar';
+import Footer from '@/components/footer';
+import Hero from '@/components/hero';
+import RichText from '@/components/richtext';
+import Sponsors, { ISponsorData } from '@/components/sponsors';
 import {
   fetchContent,
   fetchNavigationItems,
   NavigationItem,
-} from 'contentful/client';
-import { contentfulImageLoader } from 'contentful/contentfulImageLoader';
-import RichText from 'components/richtext';
-import Hero from 'components/hero';
-import { IndexDocument, IndexQuery } from 'contentful/graphql/index.graphql';
-import Footer from 'components/footer';
-import Image from 'next/image';
-import Calendar from 'components/calendar';
-import Sponsors, { ISponsorData } from 'components/sponsors';
-// import { Showlist } from 'components/showlist';
-// import Player from 'components/player';
-// import { fetchShowlist } from 'scripts/google/client';
+} from '@/contentful/client';
+import { contentfulImageLoader } from '@/contentful/contentfulImageLoader';
+import { IndexDocument, IndexQuery } from '@/contentful/graphql/index.graphql';
+// import { Showlist } from '@/components/showlist';
+// import Player from '@/components/player';
+// import { fetchShowlist } from '@/scripts/google/client';
 
 const isPlayerLive = process.env.NEXT_PUBLIC_PLAYER_MODE === 'live';
 

--- a/pages/metadata.tsx
+++ b/pages/metadata.tsx
@@ -1,8 +1,8 @@
-import { NextPage } from 'next';
 import { FormEvent, useState } from 'react';
+import { NextPage } from 'next';
 
-import { Input } from 'components/input';
-import { Button } from 'components/button';
+import { Button } from '@/components/button';
+import { Input } from '@/components/input';
 
 const Metadata: NextPage = () => {
   const [loading, setLoading] = useState(false);

--- a/pages/vuosijuhlat.tsx
+++ b/pages/vuosijuhlat.tsx
@@ -1,5 +1,5 @@
-import { useRouter } from 'next/router';
 import { useEffect } from 'react';
+import { useRouter } from 'next/router';
 
 const Vuosijuhlat = () => {
   const { push } = useRouter();

--- a/scripts/google/client.ts
+++ b/scripts/google/client.ts
@@ -1,13 +1,14 @@
+import { Color, Show, Showlist, showsToGroups } from './showlistHelpers';
 import { sheets_v4 } from '@googleapis/sheets';
 import { addMilliseconds, formatISO, getHours } from 'date-fns';
-import { getFile, getSheet } from 'scripts/google/google';
+
+import { getFile, getSheet } from '@/scripts/google/google';
 import {
   doesFileExist,
   ensureDirectoryExists,
   getImagePath,
   saveArrayBufferToFile,
-} from 'utils/fileHelpers';
-import { Color, Show, Showlist, showsToGroups } from './showlistHelpers';
+} from '@/utils/fileHelpers';
 
 const NEXT_URL = '/showlist' as const;
 const FILE_URL = `./public${NEXT_URL}` as const;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,10 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "paths": {
+      "@/*": ["*"]
+    }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules", ".cache"]


### PR DESCRIPTION
Järjestellään ja ryhmitellään importit automaattisesti: 
1. react/next/paketit
2. @/ -prefixillä olevat omat tiedostot sekä relatiiviset importit

Tähän asti ei ole varmasti pystytty erottelemaan mitkä importit ovat ns. "omia" ja mitkä node_moduleista, koska importeissa ei ollut mitään prefixiä e.g. `import Hero from 'components/hero';` nyt -> `import Hero from '@/components/hero';. Tuota `@/`-prefixiä on näkynyt paljon uusissa js-kirjastoissa ja siks valitsin sen. Vaatii ehkä vähän tottumista, mutta vscode osaa importella itsestään, joten eipä sillä väliä 🙃 

Tosiaan täysin lonkalta heitetty ehdotelma eikä pakollista missään nimessä; jaaa sisältää muutoksia vain aivan jokaiseen tiedostoon 😅 
