### PR TITLE
Fix: ohjelmakartta.jsonin luonti oli kadonnut

### DIFF
--- a/scripts/google/client.ts
+++ b/scripts/google/client.ts
@@ -1,4 +1,3 @@
-import { Color, Show, ShowsByDate, showsToGroups } from './showlistHelpers';
 import { sheets_v4 } from '@googleapis/sheets';
 import { addMilliseconds, formatISO, getHours } from 'date-fns';
 
@@ -8,7 +7,9 @@ import {
   ensureDirectoryExists,
   getImagePath,
   saveArrayBufferToFile,
+  writeFile,
 } from '@/utils/fileHelpers';
+import { Color, Show, ShowsByDate, showsToGroups } from './showlistHelpers';
 
 const NEXT_URL = '/showlist' as const;
 const FILE_URL = `./public${NEXT_URL}` as const;
@@ -116,6 +117,10 @@ export const parseSheetToShowList = async (
   return showList;
 };
 
+export const saveShowlistJson = async (data: Record<string, unknown>) => {
+  await writeFile(`${FILE_URL}/ohjelmakartta.json`, JSON.stringify(data));
+};
+
 export const fetchShowlist = async (): Promise<ShowsByDate> => {
   const data = await getSheet({
     apiKey: process.env.GA_API_KEY,
@@ -128,7 +133,10 @@ export const fetchShowlist = async (): Promise<ShowsByDate> => {
   const shows = data
     ? await parseSheetToShowList(data, { apiKey: process.env.GA_API_KEY })
     : [];
-  return showsToGroups(shows);
+
+  const showsByDate = showsToGroups(shows);
+  await saveShowlistJson(showsByDate);
+  return showsByDate;
 };
 
 const downloadShowFile = async (


### PR DESCRIPTION
Tallennetaan ohjelmakartan noudon yhteydessä json data `/showlist/ohjelmakartta.json` tiedostoon