### PR TITLE
Feature: Recognize keyword `editorial` in showlist

### DIFF
--- a/scripts/google/client.ts
+++ b/scripts/google/client.ts
@@ -89,7 +89,7 @@ export const parseSheetToShowList = async (
       const isNight = color === Color.Night || getIsNightTime(startDate);
       const showColor = isNight
         ? Color.Night
-        : color === Color.Promote
+        : (color === Color.Promote || color === Color.Editorial)
         ? Color.Promote
         : null;
 

--- a/scripts/google/showlistHelpers.ts
+++ b/scripts/google/showlistHelpers.ts
@@ -4,6 +4,7 @@ import { groupBy } from 'ramda';
 export enum Color {
   Night = 'night',
   Promote = 'promote',
+  Editorial = 'editorial',
 }
 export interface Show {
   name?: string;


### PR DESCRIPTION
Toimituksen ohjelmat voi merkitä omalla avainsanallaan ohjelmakartassa. Semanttisen pilkunviilauksen lisäksi tämä mahdollistaa, että ko. ohjelmille voidaan jatkossa määrittää sponsoriohjelmista poikkeava värikoodaus ohjelmakartan viikkonäkymässä, mikäli näin halutaan.