### PR TITLE
Hide ban button from Telegram users

### DIFF
--- a/components/ShoutBox/messageformatter.tsx
+++ b/components/ShoutBox/messageformatter.tsx
@@ -31,7 +31,7 @@ const MessageFormatter = ({
       <NameFormatter telegram={telegram} name={name} timestamp={timestamp} />
       <div className="break-words text-sm">{message}</div>
     </div>
-    {isAdmin && name !== 'Toimitus' && name !== 'Palvelin' && (
+    {isAdmin && name !== 'Toimitus' && name !== 'Palvelin' && !telegram && (
       <button
         className="m-1 inline-block cursor-pointer select-none rounded border-[1px] border-white bg-transparent px-3 py-1.5 text-center align-middle text-base font-bold text-coral"
         onClick={() => onBanClick(name)}


### PR DESCRIPTION
Oli harhaanjohtavaa et bänninappi näky tg-käyttäjille, kun ei se botti pysty bännäämään niitä. Pistin piiloon